### PR TITLE
Change api host base url to reflect new port number 5000

### DIFF
--- a/ui/src/lib/api.js
+++ b/ui/src/lib/api.js
@@ -1,6 +1,6 @@
 import { getCookie } from './cookie';
 
-export let apiHost = (process.env['REACT_APP_NODE_ENV'] === "development") ? "http://127.0.0.1:8080" : process.env['REACT_APP_API_URL'];
+export let apiHost = (process.env['REACT_APP_NODE_ENV'] === "development") ? "http://127.0.0.1:5000" : process.env['REACT_APP_API_URL'];
 
 export let createEncounter = async (patientId, encounterCode) => {
     try {


### PR DESCRIPTION
This change ensures that the baseurl of the api endpoint is matched with the currently in-operation port number 