### PR TITLE
Enable Database seeding with default/initial user 

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -41,7 +41,7 @@
     "dev": "nodemon ./src/index.ts -w ./src",
     "start": "node ./build/index.js",
     "build": "yarn tsc --project tsconfig.json",
-    "prisma:migrate": "yarn prisma migrate dev --preview-feature",
+    "prisma:migrate": "yarn prisma migrate dev --preview-feature && ts-node prisma/seed.ts",
     "prisma:deploy": "yarn prisma migrate deploy",
     "prisma:studio": "yarn prisma studio",
     "prisma:generate": "yarn prisma generate"

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "api",
     "ui"
   ],
-  "prisma": {
-    "seed": "ts-node api/prisma/seed.ts"
-  },
   "private": "true",
   "dependencies": {
     "spawn-command": "^0.0.3"


### PR DESCRIPTION
This merge enables database migrations (which create a db relations) and population of the user relation with initial Super user records with just a single migration command