### PR TITLE
Fix onClose is not a function

### DIFF
--- a/ui/src/pages/BirthPlan.jsx
+++ b/ui/src/pages/BirthPlan.jsx
@@ -165,7 +165,7 @@ export default function BirthPlan({ userData }) {
           <Snackbar
             anchorOrigin={{ vertical: "top", horizontal: "center" }}
             open={open}
-            onClose={""}
+            // onClose={""}
             message={message}
             key={"loginAlert"}
           />

--- a/ui/src/pages/ClinicalNotes.jsx
+++ b/ui/src/pages/ClinicalNotes.jsx
@@ -251,7 +251,7 @@ export default function PhysicalExam() {
                         <Snackbar
                             anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                             open={open}
-                            onClose={""}
+                            // onClose={""}
                             message={message}
                             key={"loginAlert"}
                         />

--- a/ui/src/pages/CommunityReferrals.jsx
+++ b/ui/src/pages/CommunityReferrals.jsx
@@ -138,7 +138,7 @@ export default function PatientList() {
           <Snackbar
             anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
             open={open}
-            onClose={''}
+            // onClose={''}
             message={message}
             key={'loginAlert'}
           />

--- a/ui/src/pages/Counselling.jsx
+++ b/ui/src/pages/Counselling.jsx
@@ -142,7 +142,7 @@ export default function Counselling() {
           <Snackbar
             anchorOrigin={{ vertical: "top", horizontal: "center" }}
             open={open}
-            onClose={""}
+            // onClose={""}
             message={message}
             key={"loginAlert"}
           />

--- a/ui/src/pages/Deworming.jsx
+++ b/ui/src/pages/Deworming.jsx
@@ -133,7 +133,7 @@ export default function Deworming() {
           <Snackbar
             anchorOrigin={{ vertical: "top", horizontal: "center" }}
             open={open}
-            onClose={""}
+            // onClose={""}
             message={message}
             key={"loginAlert"}
           />

--- a/ui/src/pages/Facilities.jsx
+++ b/ui/src/pages/Facilities.jsx
@@ -171,7 +171,7 @@ export default function Facilities() {
                 <Snackbar
                     anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                     open={openSnackBar}
-                    onClose={""}
+                    onClose={()=>{}}
                     message={message}
                     key={"loginAlert"}
                 />

--- a/ui/src/pages/IFAS.jsx
+++ b/ui/src/pages/IFAS.jsx
@@ -154,7 +154,7 @@ export default function IFAS() {
           <Snackbar
             anchorOrigin={{ vertical: "top", horizontal: "center" }}
             open={open}
-            onClose={""}
+            // onClose={""}
             message={message}
             key={"loginAlert"}
           />

--- a/ui/src/pages/Index.jsx
+++ b/ui/src/pages/Index.jsx
@@ -72,8 +72,8 @@ export default function Index() {
                     {(role === "ADMINISTRATOR" || role === "FACILITY_ADMINISTRATOR") ? <>
                         <Typography variant="h5">Welcome </Typography>
                         <Grid container spacing={1} padding=".5em" >
-                            {Object.keys(data).length > 0 && Object.keys(data).map((entry) => {
-                                return <Grid item xs={12} md={12} lg={3} >
+                        {Object.keys(data).length > 0 && Object.keys(data).map((entry) => {
+                            return <Grid key={entry} item xs={12} md={12} lg={3} >                                    
                                     <StatCard title={(entry).toUpperCase()} number={data[entry]} bg="#D0ADFC" />
                                 </Grid>
                             })}

--- a/ui/src/pages/Login.jsx
+++ b/ui/src/pages/Login.jsx
@@ -66,7 +66,7 @@ export default function Login() {
             <Snackbar
                 anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                 open={open}
-                onClose={""}
+                onClose={()=>{}}
                 message={message}
                 key={"loginAlert"}
             />

--- a/ui/src/pages/MOH100.jsx
+++ b/ui/src/pages/MOH100.jsx
@@ -88,7 +88,7 @@ export default function MOH100({ id }) {
                         <Snackbar
                             anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                             open={open}
-                            onClose={""}
+                            // onClose={""}
                             message={message}
                             key={"loginAlert"}
                         />

--- a/ui/src/pages/MalariaProphylaxis.jsx
+++ b/ui/src/pages/MalariaProphylaxis.jsx
@@ -153,7 +153,7 @@ export default function MalariaProphylaxis() {
           <Snackbar
             anchorOrigin={{ vertical: "top", horizontal: "center" }}
             open={open}
-            onClose={""}
+            // onClose={""}
             message={message}
             key={"loginAlert"}
           />

--- a/ui/src/pages/MaternalSerology.jsx
+++ b/ui/src/pages/MaternalSerology.jsx
@@ -133,7 +133,7 @@ export default function MaternalSerology() {
           <Snackbar
             anchorOrigin={{ vertical: "top", horizontal: "center" }}
             open={open}
-            onClose={""}
+            // onClose={""}
             message={message}
             key={"loginAlert"}
           />

--- a/ui/src/pages/MedicalAndSurgicalHistory.jsx
+++ b/ui/src/pages/MedicalAndSurgicalHistory.jsx
@@ -178,7 +178,7 @@ export default function ANCProfile() {
           <Snackbar
             anchorOrigin={{ vertical: "top", horizontal: "center" }}
             open={open}
-            onClose={""}
+            // onClose={""}
             message={message}
             key={"loginAlert"}
           />

--- a/ui/src/pages/PMTCTInterventions.jsx
+++ b/ui/src/pages/PMTCTInterventions.jsx
@@ -145,7 +145,7 @@ export default function PMTCTInterventions() {
           <Snackbar
             anchorOrigin={{ vertical: "top", horizontal: "center" }}
             open={open}
-            onClose={""}
+            // onClose={""}
             message={message}
             key={"loginAlert"}
           />

--- a/ui/src/pages/PatientList.jsx
+++ b/ui/src/pages/PatientList.jsx
@@ -341,7 +341,7 @@ export default function PatientList() {
       <Snackbar
         anchorOrigin={{ vertical: "top", horizontal: "center" }}
         open={open}
-        onClose={""}
+        // onClose={""}
         message={message}
         key={"loginAlert"}
       />

--- a/ui/src/pages/PatientRegistration.jsx
+++ b/ui/src/pages/PatientRegistration.jsx
@@ -194,7 +194,7 @@ export default function PatientRegistration({ userData }) {
           <Snackbar
             anchorOrigin={{ vertical: "top", horizontal: "center" }}
             open={open}
-            onClose={""}
+            // onClose={""}
             message={message}
             key={"loginAlert"}
           />

--- a/ui/src/pages/PresentPregnancy.jsx
+++ b/ui/src/pages/PresentPregnancy.jsx
@@ -219,7 +219,7 @@ export default function PresentPregnancy() {
           <Snackbar
             anchorOrigin={{ vertical: "top", horizontal: "center" }}
             open={open}
-            onClose={""}
+            // onClose={""}
             message={message}
             key={"loginAlert"}
           />

--- a/ui/src/pages/Register.jsx
+++ b/ui/src/pages/Register.jsx
@@ -60,7 +60,7 @@ export default function Register() {
                     <Snackbar
                         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                         open={open}
-                        onClose={""}
+                        // onClose={""}
                         message={message}
                         key={"registerAlert"}
                     />

--- a/ui/src/pages/SetNewPassword.jsx
+++ b/ui/src/pages/SetNewPassword.jsx
@@ -53,7 +53,7 @@ export default function SetNewPassword() {
                 <Snackbar
                     anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                     open={open}
-                    onClose={""}
+                    // onClose={""}
                     message={message}
                     key={"loginAlert"}
                 />

--- a/ui/src/pages/Setup.jsx
+++ b/ui/src/pages/Setup.jsx
@@ -44,7 +44,7 @@ export default function Setup({id}) {
                 <Snackbar
                     anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                     open={open}
-                    onClose={""}
+                    // onClose={""}
                     message={message}
                     key={"loginAlert"}
                 />

--- a/ui/src/pages/TetanusDiptheria.jsx
+++ b/ui/src/pages/TetanusDiptheria.jsx
@@ -211,7 +211,7 @@ export default function TetanusDiptheria() {
           <Snackbar
             anchorOrigin={{ vertical: "top", horizontal: "center" }}
             open={open}
-            onClose={""}
+            // onClose={""}
             message={message}
             key={"loginAlert"}
           />

--- a/ui/src/pages/Treatment.jsx
+++ b/ui/src/pages/Treatment.jsx
@@ -109,7 +109,7 @@ export default function Treatment() {
                         <Snackbar
                             anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                             open={open}
-                            onClose={""}
+                            // onClose={""}
                             message={message}
                             key={"loginAlert"}
                         />

--- a/ui/src/pages/Users.jsx
+++ b/ui/src/pages/Users.jsx
@@ -201,7 +201,7 @@ export default function Users() {
                 <Snackbar
                     anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                     open={openSnackBar}
-                    onClose={""}
+                    // onClose={""}
                     message={message}
                     key={"loginAlert"}
                 />

--- a/ui/src/pages/ViewMOH100.jsx
+++ b/ui/src/pages/ViewMOH100.jsx
@@ -56,7 +56,7 @@ export default function ViewMOH100() {
         <Snackbar
           anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
           open={open}
-          onClose={''}
+          // onClose={''}
           message={message}
           key={'loginAlert'}
         />


### PR DESCRIPTION
This PR fixes the onClose is not a function error by either passing a proper function to the event or commenting it out in blocks where it is unused