### PR TITLE
Align ANC forms field names with corresponding observation coding system

### DIFF
--- a/ui/src/lib/forms/deworming.js
+++ b/ui/src/lib/forms/deworming.js
@@ -30,7 +30,7 @@ const deworming = {
         md: 12,
         lg: 6,
       },
-      relevant: formValues => formValues.dewormingGiven === 'Yes',
+      relevant: formValues => formValues.dewormingDeworming === 'Yes',
     },
   ],
 };

--- a/ui/src/lib/forms/ifas.js
+++ b/ui/src/lib/forms/ifas.js
@@ -4,7 +4,7 @@ import ifasOptions from '../../data/ifas.json';
 const ifas = {
   'Supplements Issuing to Client': [
     {
-      name: 'supplementsIssued',
+      name: 'iFASIronSuppliments',
       label: 'Were iron supplements issued to the patient?',
       type: 'radio',
       validate: yup
@@ -22,7 +22,7 @@ const ifas = {
       ],
     },
     {
-      name: 'drugName',
+      name: 'iFASDrugGiven',
       label: 'If yes, specify the drug given',
       type: 'radio',
       validate: yup.string(),
@@ -36,10 +36,10 @@ const ifas = {
         { label: 'Elemental iron', value: 'Elemental iron' },
         { label: 'Combined tablets', value: 'Combined tablets' },
       ],
-      relevant: formValues => formValues.supplementsIssued === 'Yes',
+      relevant: formValues => formValues.iFASIronSuppliments === 'Yes',
     },
     {
-      name: 'reasonNotIssued',
+      name: 'iFASReason',
       label: 'If no, provide reason',
       type: 'text',
       validate: yup.string(),
@@ -49,10 +49,10 @@ const ifas = {
         md: 12,
         lg: 6,
       },
-      relevant: formValues => formValues.supplementsIssued === 'No',
+      relevant: formValues => formValues.iFASIronSuppliments === 'No',
     },
     {
-      name: 'equivalentDose',
+      name: 'iFASOtherSuppliments',
       label: 'Any other equivalent provided',
       type: 'text',
       validate: yup.string(),
@@ -66,7 +66,7 @@ const ifas = {
   ],
   'ANC Contact': [
     {
-      name: 'ancContact',
+      name: 'iFASAncContact',
       label: 'ANC Contact',
       type: 'select',
       validate: yup.string().required('ANC Contact is required'),
@@ -82,7 +82,7 @@ const ifas = {
       })),
     },
     {
-      name: 'timingOfContact',
+      name: 'iFASContactTiming',
       label: 'Timing of contact',
       type: 'display',
       content: '',
@@ -92,10 +92,10 @@ const ifas = {
         md: 12,
         lg: 12,
       },
-      relevant: formValues => formValues.ancContact,
+      relevant: formValues => formValues.iFASAncContact,
     },
     {
-      name: 'noOfTablets',
+      name: 'iFASNoOfTablets',
       label: 'No of tablets',
       type: 'display',
       content: '',
@@ -105,7 +105,7 @@ const ifas = {
         md: 12,
         lg: 12,
       },
-      relevant: formValues => formValues.ancContact,
+      relevant: formValues => formValues.iFASAncContact,
     },
   ],
   Dosage: [
@@ -146,7 +146,7 @@ const ifas = {
       },
     },
     {
-      name: 'benefitsCounselingDone',
+      name: 'dosageIronAndFolicCounsellingDone',
       label: 'Was benefits of iron and folic acid counseling done?',
       type: 'radio',
       validate: yup

--- a/ui/src/lib/forms/malariaProphylaxis.js
+++ b/ui/src/lib/forms/malariaProphylaxis.js
@@ -100,7 +100,7 @@ const malariaProphylaxis = {
       ],
     },
     {
-      name: 'malariaProphylaxisLLITNYesResulst',
+      name: 'malariaProphylaxisLLITNYesResult',
       label: 'If yes, date given',
       type: 'date',
       validate: yup.date(),

--- a/ui/src/lib/forms/medicalSurgicalHistory.js
+++ b/ui/src/lib/forms/medicalSurgicalHistory.js
@@ -221,7 +221,7 @@ const medicalSurgicalHistory = {
       relevant: values => values.drugAllergies === 'Yes',
     },
     {
-      name: 'otherNonDrugAllergies',
+      name: 'nonDrugAllergies',
       label: 'Other Non-Drug Allergies',
       type: 'radio',
       validate: yup.string(),
@@ -247,7 +247,7 @@ const medicalSurgicalHistory = {
         md: 12,
         lg: 6,
       },
-      relevant: values => values.otherNonDrugAllergies === 'Yes',
+      relevant: values => values.nonDrugAllergies === 'Yes',
     },
   ],
   'Family History': [

--- a/ui/src/lib/forms/presentPregnancy.js
+++ b/ui/src/lib/forms/presentPregnancy.js
@@ -147,7 +147,7 @@ const presentPregnancy = {
       ],
     },
     {
-      name: 'gestationalAge',
+      name: 'hbTestGestation',
       label: 'Gestation in weeks',
       type: 'text',
       validate: yup.number().required('Gestational age is required'),


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done (including the ticket number if available).
- [X] My work conforms to the outlined coding, styling and documentation styles.

## Summary
This PR eradicates the "Observation key for [insert observation name here] not found" error for the modified forms. This ensures that all identified observations are created and stored using the observation resource.
<!--
Required
Please describe the problem/issue that your PR addresses
-->

## Screenshots

*None.* 
<!--
Optional
It is highly recommended you insert any screenshots/videos of your changes here. 
If you fill this section, please remove the *None.* above.
-->

## Related issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.github.mamashub-web.org/browse.123".
Do not forget to remove the *None.* above if you fill this section aswell.
-->

## Other

*None.*
<!--
Optional.
Please include anything else that is not covered in the above sections here.
Don't forget to remove the *None.* above if you do fill in this section.
-->

## Reviewers
@1wes @DavidSaruni.