### PR TITLE
fix(FormFields): handle undefined array in checkbox onChange handler

### DIFF
--- a/ui/src/components/FormFields.js
+++ b/ui/src/components/FormFields.js
@@ -73,15 +73,19 @@ export default function FormFields({ formik, formData, encounters, ...props }) {
   };
 
   const handleChangeChecked = (e, field, option) => {
+    const currentValues = formik.values[field.name] || [];
+
     if (e.target.checked) {
       formik.setFieldValue(
         field.name,
-        formik.values[field.name].concat(option.value)
+        currentValues.concat(option.value)
       );
     } else {
       formik.setFieldValue(
         field.name,
-        formik.values[field.name].filter(item => item !== option.value)
+      Array.isArray(currentValues)
+        ? currentValues.filter(item => item !== option.value)
+        : []
       );
     }
     console.log(field.name + ':', formik.values[field.name]);


### PR DESCRIPTION
## Description

Fix TypeError that occurs when handling undefined arrays in checkbox onChange events. This addresses the issue where unchecking a checkbox would throw an error due to attempting to call .filter on an undefined value.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
<!-- Check all items that apply: -->
- [x] I have followed the coding standards for this project.
- [x] My code has been linted and formatted.
- [ ] The changes require review by another team member (add reviewer).

## How Has This Been Tested?
Tested the following scenarios:
1. Checkbox selection with empty initial values
2. Checkbox selection with existing values
3. Checkbox deselection
4. Form reset behavior

Steps to reproduce:
1. Navigate to any form with checkboxes
2. Try selecting/deselecting checkboxes
3. Verify no errors occur in console
4. Verify form values update correctly

## Related Issues
Fixes TypeError: formik.values[field.name].filter is not a function

## Further Comments
The fix implements a safe fallback to empty array when formik values are undefined, preventing the TypeError while maintaining expected functionality. The implementation uses a defensive approach to ensure array operations are always performed on valid arrays.

